### PR TITLE
Feature/streaming csvs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,39 @@ stream.each_slice(100) do |lines|
 end
 ```
 
+##### CSVs
+
+This gem provides first-class support for streaming CSVs from a remote URL.
+
+```ruby
+url = 'https://my.remote.file/file.csv'
+stream = StreamLines::Reading::CSV.new(url)
+
+stream.each do |row|
+  # each row will be an array
+end
+
+# Supports most Ruby CSV options (see ignored options below)
+stream = StreamLines::Reading::CSV.new(url, headers: true)
+
+stream.each do |row|
+  # each row is a CSV::Row object that you can access like row['column_name']
+end
+```
+
+Most options that you can pass to
+[Ruby's CSV library](https://ruby-doc.org/stdlib-2.6.1/libdoc/csv/rdoc/CSV.html#method-c-new)
+are supported; however, the following options are explicitly ignored:
+
+* `return_headers`
+* `header_converters`
+* `skip_lines`
+
+I suspect that these options are not used terribly frequently, and each would
+require additional logic in the `StreamLines::Reading::CSV#each` method.
+Rather than attempting to implement sensible solutions for these options, I am
+choosing to explicitly ignore them until there is enough outcry to support them.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies.

--- a/lib/stream_lines/reading/csv.rb
+++ b/lib/stream_lines/reading/csv.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'stream_lines/error'
+require 'stream_lines/reading/stream'
+
+module StreamLines
+  module Reading
+    class CSV
+      # NOTE: (jdlubrano)
+      # I suspect that these options are not used terribly frequently, and each
+      # would require additional logic in the #each method.  Rather than
+      # attempting to implement sensible solutions for these options, I am
+      # choosing to explicitly ignore them until there is enough outcry to
+      # support them.
+      IGNORED_CSV_OPTIONS = %i[
+        return_headers
+        header_converters
+        skip_lines
+      ].freeze
+
+      include Enumerable
+
+      def initialize(url, **csv_options)
+        @url = url
+        @csv_options = accepted_csv_options(csv_options)
+        @stream = Stream.new(url)
+      end
+
+      def each(&block)
+        @stream.each_with_index do |line, i|
+          next assign_first_row_headers(line) if i.zero? && first_row_headers?
+
+          block.call(::CSV.parse_line(line, **@csv_options))
+        end
+      end
+
+      private
+
+      attr_reader :url
+
+      def first_row_headers?
+        @csv_options[:headers] == true
+      end
+
+      def assign_first_row_headers(first_line)
+        header_row = ::CSV.parse_line(first_line)
+        @csv_options[:headers] = header_row
+      end
+
+      def accepted_csv_options(csv_options)
+        csv_options.transform_keys(&:to_sym)
+                   .delete_if { |key, _value| IGNORED_CSV_OPTIONS.include?(key) }
+      end
+    end
+  end
+end

--- a/spec/reading/csv_spec.rb
+++ b/spec/reading/csv_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'stream_lines/reading/csv'
+
+RSpec.describe StreamLines::Reading::CSV do
+  let(:url) { 'https://test.stream_lines.com' }
+  let(:csv) { described_class.new(url) }
+
+  it { expect(csv).to be_an(Enumerable) }
+
+  describe '#each' do
+    let(:csv_content) do
+      <<~CSV
+        foo,bar
+        1,2
+        3,4
+      CSV
+    end
+
+    subject(:streamed_rows) do
+      [].tap do |rows|
+        csv.each { |row| rows << row }
+      end
+    end
+
+    context 'when the request to fetch the CSV succeeds' do
+      let(:csv) { described_class.new(url) }
+
+      before do
+        WebMock.stub_request(:get, url)
+               .to_return(status: 200, body: csv_content)
+      end
+
+      context 'when the headers option is false' do
+        it 'yields Arrays' do
+          expect(streamed_rows).to all be_an(Array)
+        end
+
+        it 'returns the headers as the first row' do
+          expect(streamed_rows.first).to eq(%w[foo bar])
+        end
+
+        it 'correctly yields the all of the data' do
+          expect(streamed_rows).to eq([%w[foo bar],
+                                       %w[1 2],
+                                       %w[3 4]])
+        end
+      end
+
+      context 'when the headers option is true' do
+        let(:csv) { described_class.new(url, headers: true) }
+
+        it 'yields CSV::Rows' do
+          expect(streamed_rows).to all be_a(::CSV::Row)
+        end
+
+        it 'uses the first row as the headers' do
+          expect(streamed_rows.first.headers).to eq(%w[foo bar])
+        end
+
+        it 'correctly yields all of the data' do
+          expect(streamed_rows.map(&:to_h)).to eq([{ 'foo' => '1', 'bar' => '2' },
+                                                   { 'foo' => '3', 'bar' => '4' }])
+        end
+      end
+
+      context 'when the headers are provided as an array' do
+        let(:csv) { described_class.new(url, headers: headers) }
+        let(:headers) { %w[column_1 column_2] }
+
+        it 'yields CSV::Rows' do
+          expect(streamed_rows).to all be_a(::CSV::Row)
+        end
+
+        it 'yields the first row with the given headers' do
+          expect(streamed_rows.first.to_h).to eq('column_1' => 'foo', 'column_2' => 'bar')
+        end
+
+        it 'correctly yields all of the data' do
+          expect(streamed_rows.map(&:to_h)).to eq([{ 'column_1' => 'foo', 'column_2' => 'bar' },
+                                                   { 'column_1' => '1', 'column_2' => '2' },
+                                                   { 'column_1' => '3', 'column_2' => '4' }])
+        end
+      end
+
+      context 'when converters are provided' do
+        let(:csv) { described_class.new(url, converters: [:integer]) }
+
+        it 'converts all of the data' do
+          expect(streamed_rows).to eq([%w[foo bar],
+                                       [1, 2],
+                                       [3, 4]])
+        end
+      end
+    end
+
+    context 'when the request to fetch the CSV fails' do
+      before do
+        WebMock.stub_request(:get, url).to_return(status: 404)
+      end
+
+      it 'raises an error' do
+        expect { streamed_rows }.to raise_error(StreamLines::Error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Provides first-class support for streaming CSVs from a remote URL.

```ruby
url = 'https://my.remote.file/file.csv'
stream = StreamLines::Reading::CSV.new(url)

stream.each do |row|
  # each row will be an array
end

# Supports most Ruby CSV options (see ignored options below)
stream = StreamLines::Reading::CSV.new(url, headers: true)

stream.each do |row|
  # each row is a CSV::Row object that you can access like row['column_name']
end
```

Most options that you can pass to [Ruby's CSV library](https://ruby-doc.org/stdlib-2.6.1/libdoc/csv/rdoc/CSV.html#method-c-new) are supported; however, the following options are explicitly ignored:

* `return_headers`
* `header_converters`
* `skip_lines`

I suspect that these options are not used terribly frequently, and each would require additional logic in the `StreamLines::Reading::CSV#each` method. Rather than attempting to implement sensible solutions for these options, I am choosing to explicitly ignore them until there is enough outcry to support them.