### PR TITLE
Initialize a new StringIO rather than truncating

### DIFF
--- a/lib/stream_lines/reading/stream.rb
+++ b/lib/stream_lines/reading/stream.rb
@@ -43,7 +43,7 @@ module StreamLines
         if lines.length > 1
           @buffer.rewind
           lines.first.prepend(@buffer.read)
-          @buffer.truncate(0)
+          @buffer = StringIO.new
         end
 
         @buffer << lines.pop


### PR DESCRIPTION
I was seeing rather inexplicable behavior in a production application where null bytes were being added to the beginning of streamed lines.  I was able to debug and observe that the `StringIO` buffer would accumulate `\u0000` bytes, but I have no idea why.  In any case, initializing a new `StringIO` instead of truncating seems to fix the issue.