### PR TITLE
Fix Double Printed Headers with `first`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,37 @@ stream.each_slice(100) do |lines|
 end
 ```
 
+##### Caveats
+
+This library strives to provide streamed data via an `Enumerable` interface.
+In order to be memory-efficient, however, each time the stream is iterated over,
+a new GET request is made to fetch the data from its remote URL.  For example,
+
+```ruby
+url = 'https://my.remote.file/file.txt'
+stream = StreamLines::Reading::Stream.new(url)
+do_something_with_first_row(stream.first) # GET request made
+
+stream.each do |line| # same GET request made
+  # Do something with the line of data (the line will be a String)
+end
+```
+
+makes two GET requests.  The call to `first` makes a GET request to fetch
+the first row of data.  The subsequent call to `each` makes the same GET
+request.  To avoid unnecessary requests, I recommend a slightly different
+approach, which may not be intuitive but does make only one network request:
+
+```
+url = 'https://my.remote.file/file.txt'
+stream = StreamLines::Reading::Stream.new(url)
+
+stream.each_with_index do |line, i|
+  do_something_with_first_row(line) if i.zero?
+  # Do something with the line of data (the line will be a String)
+end
+```
+
 ##### CSVs
 
 This gem provides first-class support for streaming CSVs from a remote URL.

--- a/lib/stream_lines/reading/csv.rb
+++ b/lib/stream_lines/reading/csv.rb
@@ -23,6 +23,7 @@ module StreamLines
       def initialize(url, **csv_options)
         @url = url
         @csv_options = accepted_csv_options(csv_options)
+        @first_row_headers = @csv_options[:headers] == true
 
         encoding = @csv_options[:encoding] || Encoding.default_external
         @stream = Stream.new(url, encoding: encoding)
@@ -41,7 +42,7 @@ module StreamLines
       attr_reader :url
 
       def first_row_headers?
-        @csv_options[:headers] == true
+        @first_row_headers
       end
 
       def assign_first_row_headers(first_line)

--- a/spec/reading/csv_spec.rb
+++ b/spec/reading/csv_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe StreamLines::Reading::CSV do
           expect(streamed_rows.map(&:to_h)).to eq([{ 'foo' => '1', 'bar' => '2' },
                                                    { 'foo' => '3', 'bar' => '4' }])
         end
+
+        it 'correctly yields all of the data' do
+          stream = described_class.new(url, headers: true)
+
+          cloud = []
+          cloud << stream.first.headers.to_csv
+          stream.each do |row|
+            cloud << row.fields.to_csv
+          end
+          expect(cloud).to eq ["foo,bar\n", "1,2\n", "3,4\n"]
+        end
       end
 
       context 'when the headers are provided as an array' do


### PR DESCRIPTION
Fixes #127 